### PR TITLE
Make bower installation work correctly

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "version": "0.2.0",
   "main": "dist/backbone.handlebars.min.js",
   "dependencies": {
-    "backbone": "~0.9.9"
+    "backbone": "1.x"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "main": "dist/backbone.handlebars.min.js",
   "dependencies": {
-    "backbone": "1.x"
+    "backbone": "1.x",
+    "handlebars": "3.x"
   }
 }


### PR DESCRIPTION
This project would not install for me via bower because of a) using component.json instead of bower.json as a package spec file, b) version mismatches with the current production version of Backbone (1.2.0), and c) not specifying it's dependency on Handlebars. Installing in a current Backbone app with bower should now work correctly with this patch.
